### PR TITLE
SonarCloud cleanup for FlashCardsGUI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,17 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 ENV HUSKY=0
 COPY package.json package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts
 
 FROM base AS builder
 WORKDIR /app
 
-RUN apk add --no-cache --virtual .build-deps python3 make g++
+RUN apk add --no-cache --virtual .build-deps g++ make python3
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY package.json package-lock.json next.config.ts next-env.d.ts tsconfig.json ./
+COPY messages ./messages
+COPY public ./public
+COPY src ./src
 
 RUN --mount=type=cache,target=/root/.npm npm run build
 
@@ -29,8 +32,8 @@ ENV NODE_ENV=production \
 
 USER node
 
-COPY --chown=node:node --from=builder /app/.next/standalone ./
-COPY --chown=node:node --from=builder /app/.next/static     ./.next/static
-COPY --chown=node:node --from=builder /app/public            ./public
+COPY --chown=node:node --chmod=0555 --from=builder /app/.next/standalone ./
+COPY --chown=node:node --chmod=0555 --from=builder /app/.next/static ./.next/static
+COPY --chown=node:node --chmod=0555 --from=builder /app/public ./public
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,13 @@ ENV NODE_ENV=production \
     PORT=3000 \
     HOSTNAME=0.0.0.0
 
-USER node
-
 COPY --chown=root:root --chmod=0555 --from=builder /app/.next/standalone ./
 COPY --chown=root:root --chmod=0555 --from=builder /app/.next/static ./.next/static
 COPY --chown=root:root --chmod=0555 --from=builder /app/public ./public
+
+# Keep app assets read-only, but leave Next.js runtime cache writable for the app user.
+RUN mkdir -p .next/cache && chown -R node:node .next/cache && chmod 0755 .next/cache
+
+USER node
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 RUN apk add --no-cache --virtual .build-deps g++ make python3
 COPY --from=deps /app/node_modules ./node_modules
-COPY package.json package-lock.json next.config.ts next-env.d.ts tsconfig.json ./
+COPY package.json package-lock.json next.config.ts tsconfig.json ./
 COPY messages ./messages
 COPY public ./public
 COPY src ./src

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ENV NODE_ENV=production \
 
 USER node
 
-COPY --chown=node:node --chmod=0555 --from=builder /app/.next/standalone ./
-COPY --chown=node:node --chmod=0555 --from=builder /app/.next/static ./.next/static
-COPY --chown=node:node --chmod=0555 --from=builder /app/public ./public
+COPY --chown=root:root --chmod=0555 --from=builder /app/.next/standalone ./
+COPY --chown=root:root --chmod=0555 --from=builder /app/.next/static ./.next/static
+COPY --chown=root:root --chmod=0555 --from=builder /app/public ./public
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,8 +2,8 @@ FROM node:22.17-alpine3.22
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm install
+COPY package-lock.json package.json ./
+RUN npm ci --ignore-scripts
 
 ENV NODE_ENV=development
 ENV HOST=0.0.0.0

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,10 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { FlatCompat } from '@eslint/eslintrc';
 import prettierConfig from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/src/app/[locale]/Providers.tsx
+++ b/src/app/[locale]/Providers.tsx
@@ -9,11 +9,11 @@ import { ReactNode, useEffect } from 'react';
 import { loadAuthTokenFromCookie, setApiClientLocale } from '@/lib/apiClient';
 import theme from '@/styles/theme';
 
-type ProvidersProps = {
+type ProvidersProps = Readonly<{
   children: ReactNode;
   locale: string;
   messages: Record<string, unknown>;
-};
+}>;
 
 export function Providers({ children, locale, messages }: ProvidersProps) {
   useEffect(() => {

--- a/src/app/[locale]/auth/login/LoginForm.tsx
+++ b/src/app/[locale]/auth/login/LoginForm.tsx
@@ -44,7 +44,7 @@ export default function LoginForm() {
       parsed.error.issues.forEach(issue => {
         const field = issue.path[0];
         if (field === 'login' || field === 'password') {
-          setError(field, { type: 'manual', message: t(issue.message as string) });
+          setError(field, { type: 'manual', message: t(issue.message) });
         }
       });
       return;

--- a/src/app/[locale]/auth/register/RegisterForm.tsx
+++ b/src/app/[locale]/auth/register/RegisterForm.tsx
@@ -21,7 +21,7 @@ const registerSchema = z
   .object({
     username: z
       .string()
-      .regex(/^[a-zA-Z0-9_]+$/, 'register.errors.usernameInvalid')
+      .regex(/^\w+$/, 'register.errors.usernameInvalid')
       .max(16, 'register.errors.usernameMax')
       .min(4, 'register.errors.usernameRequired'),
     email: z.email('register.errors.invalidEmail'),
@@ -79,7 +79,7 @@ const RegisterForm = () => {
           field === 'confirmPassword' ||
           field === 'agreeToTerms'
         ) {
-          setError(field, { type: 'manual', message: t(issue.message as string) });
+          setError(field, { type: 'manual', message: t(issue.message) });
         }
       });
       return;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -15,7 +15,12 @@ const roboto = Roboto({
   variable: '--font-roboto',
 });
 
-export default async function RootLayout({ children, params }: { children: React.ReactNode; params: Promise<{ locale: string }> }) {
+type RootLayoutProps = Readonly<{
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}>;
+
+export default async function RootLayout({ children, params }: RootLayoutProps) {
   const { locale } = await params;
   if (!hasLocale(routing.locales, locale)) {
     notFound();

--- a/src/app/api/log-to-loki/route.ts
+++ b/src/app/api/log-to-loki/route.ts
@@ -28,11 +28,11 @@ export async function POST(req: Request) {
       console.log(serializedLog);
     }
 
-    recordRequest('/api/log-to-loki', '200', Date.now() - start, 'POST');
+    recordRequest('/api/log-to-loki', Date.now() - start, '200', 'POST');
     return new Response('ok');
   } catch (error) {
     console.error('Error logging to Loki:', error);
-    recordRequest('/api/log-to-loki', '500', Date.now() - start, 'POST');
+    recordRequest('/api/log-to-loki', Date.now() - start, '500', 'POST');
     return new Response('error', { status: 500 });
   }
 }

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -56,8 +56,8 @@ const LanguageSwitcher = () => {
             'aria-labelledby': 'basic-button',
           },
         }}>
-        {routing.locales.map((l, i) => (
-          <MenuItem key={i} onClick={() => handleSwitchLanguage(l)} disabled={l === locale}>
+        {routing.locales.map(l => (
+          <MenuItem key={l} onClick={() => handleSwitchLanguage(l)} disabled={l === locale}>
             <Image src={`/images/flags/${l}.png`} alt={`${l} flag`} width={32} height={32} style={{ marginRight: '0.5rem' }} />
             {l.toUpperCase()}
           </MenuItem>

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -35,8 +35,8 @@ type PasswordFieldWithMeterProps = BasePasswordFieldProps & {
 
 type PasswordFieldWithoutMeterProps = BasePasswordFieldProps & {
   strengthMeter?: false;
-  watch?: undefined;
-  isDirty?: undefined;
+  watch?: never;
+  isDirty?: never;
 };
 
 type PasswordFieldProps = PasswordFieldWithMeterProps | PasswordFieldWithoutMeterProps;

--- a/src/helpers/logToLoki.ts
+++ b/src/helpers/logToLoki.ts
@@ -4,7 +4,7 @@ export async function logToLoki(data: { level: string; msg: string; [key: string
     ...data,
     level: data.level.toLowerCase(),
     timestamp: new Date().toISOString(),
-    path: window.location.pathname,
+    path: globalThis.window.location.pathname,
     userAgent: navigator.userAgent,
   };
 

--- a/src/hooks/usePasswordStrength.ts
+++ b/src/hooks/usePasswordStrength.ts
@@ -46,7 +46,7 @@ const calculatePasswordStrength = (password: string): PasswordStrength => {
 
   const hasLower = /[a-z]/.test(password);
   const hasUpper = /[A-Z]/.test(password);
-  const hasNumber = /[0-9]/.test(password);
+  const hasNumber = /\d/.test(password);
   const hasSymbol = /[^A-Za-z0-9]/.test(password);
 
   const varietyCount = [hasLower, hasUpper, hasNumber, hasSymbol].filter(Boolean).length;

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -50,7 +50,7 @@ apiClient.interceptors.response.use(
   error => {
     const status = error?.response?.status;
     const url: string | undefined = error?.config?.url;
-    const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+    const browserWindow = globalThis.window;
 
     const isLoginRequest = url?.includes('/auth/login');
 

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -50,16 +50,17 @@ apiClient.interceptors.response.use(
   error => {
     const status = error?.response?.status;
     const url: string | undefined = error?.config?.url;
+    const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
 
     const isLoginRequest = url?.includes('/auth/login');
 
-    if (!isLoginRequest && (status === 401 || status === 403) && typeof window !== 'undefined') {
+    if (!isLoginRequest && (status === 401 || status === 403) && browserWindow) {
       setAuthToken(null);
 
-      const segments = window.location.pathname.split('/');
+      const segments = browserWindow.location.pathname.split('/');
       const locale = segments[1] || 'pl';
 
-      window.location.href = `/${locale}/auth/login`;
+      browserWindow.location.href = `/${locale}/auth/login`;
     }
 
     return Promise.reject(error);

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -1,58 +1,55 @@
-import { collectDefaultMetrics, Counter, Gauge, Histogram, register } from 'prom-client';
+import { collectDefaultMetrics, Counter, Gauge, Histogram, register as metricsRegister } from 'prom-client';
+
+export { register } from 'prom-client';
 
 const APP_NAME = process.env.APP_NAME || 'frontend';
 const METRICS_PREFIX = process.env.METRICS_PREFIX || 'frontend_';
-const BUCKETS = (process.env.METRICS_BUCKETS || '50,100,300,1000,2000,3000').split(',').map(b => Number(b));
+const BUCKETS = (process.env.METRICS_BUCKETS || '50,100,300,1000,2000,3000').split(',').map(Number);
 
-if (!register.getSingleMetric(`${METRICS_PREFIX}process_cpu_user_seconds_total`)) {
+if (!metricsRegister.getSingleMetric(`${METRICS_PREFIX}process_cpu_user_seconds_total`)) {
   collectDefaultMetrics({ prefix: METRICS_PREFIX });
 }
 
-let requestCounter = register.getSingleMetric(`${APP_NAME}_requests_total`) as Counter<string>;
-if (!requestCounter) {
-  requestCounter = new Counter({
+const requestCounter =
+  (metricsRegister.getSingleMetric(`${APP_NAME}_requests_total`) as Counter<string> | undefined) ??
+  new Counter({
     name: `${APP_NAME}_requests_total`,
     help: 'Total number of HTTP requests',
     labelNames: ['method', 'path', 'status'],
   });
-}
 
-let errorCounter = register.getSingleMetric(`${APP_NAME}_errors_total`) as Counter<string>;
-if (!errorCounter) {
-  errorCounter = new Counter({
+const errorCounter =
+  (metricsRegister.getSingleMetric(`${APP_NAME}_errors_total`) as Counter<string> | undefined) ??
+  new Counter({
     name: `${APP_NAME}_errors_total`,
     help: 'Total number of HTTP 4xx/5xx errors',
     labelNames: ['method', 'path', 'status'],
   });
-}
 
-let requestDuration = register.getSingleMetric(`${APP_NAME}_request_duration_ms`) as Histogram<string>;
-if (!requestDuration) {
-  requestDuration = new Histogram({
+const requestDuration =
+  (metricsRegister.getSingleMetric(`${APP_NAME}_request_duration_ms`) as Histogram<string> | undefined) ??
+  new Histogram({
     name: `${APP_NAME}_request_duration_ms`,
     help: 'Duration of HTTP requests in milliseconds',
     labelNames: ['method', 'path', 'status'],
     buckets: BUCKETS,
   });
-}
 
-let activeSessions = register.getSingleMetric(`${APP_NAME}_active_sessions`) as Gauge<string>;
-if (!activeSessions) {
-  activeSessions = new Gauge({
+const activeSessions =
+  (metricsRegister.getSingleMetric(`${APP_NAME}_active_sessions`) as Gauge<string> | undefined) ??
+  new Gauge({
     name: `${APP_NAME}_active_sessions`,
     help: 'Number of active sessions (fake)',
   });
-}
 
-let cacheSize = register.getSingleMetric(`${APP_NAME}_cache_items`) as Gauge<string>;
-if (!cacheSize) {
-  cacheSize = new Gauge({
+const cacheSize =
+  (metricsRegister.getSingleMetric(`${APP_NAME}_cache_items`) as Gauge<string> | undefined) ??
+  new Gauge({
     name: `${APP_NAME}_cache_items`,
     help: 'Simulated number of items in cache',
   });
-}
 
-export function recordRequest(path: string, status = '200', durationMs: number, method = 'GET') {
+export function recordRequest(path: string, durationMs: number, status = '200', method = 'GET') {
   requestCounter.labels(method, path, status).inc();
   requestDuration.labels(method, path, status).observe(durationMs);
 
@@ -61,4 +58,4 @@ export function recordRequest(path: string, status = '200', durationMs: number, 
   }
 }
 
-export { activeSessions, cacheSize, errorCounter, register, requestCounter, requestDuration };
+export { activeSessions, cacheSize, errorCounter, requestCounter, requestDuration };

--- a/tests/unit/Providers.test.tsx
+++ b/tests/unit/Providers.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { loadAuthTokenFromCookieMock, setApiClientLocaleMock } = vi.hoisted(() => ({
+  loadAuthTokenFromCookieMock: vi.fn(),
+  setApiClientLocaleMock: vi.fn(),
+}));
+
+vi.mock('@/lib/apiClient', () => ({
+  loadAuthTokenFromCookie: loadAuthTokenFromCookieMock,
+  setApiClientLocale: setApiClientLocaleMock,
+}));
+vi.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { Providers } from '@/app/[locale]/Providers';
+
+describe('Providers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children and initializes locale-specific API setup', async () => {
+    render(
+      <Providers locale="pl" messages={{ appName: 'FlashCards' }}>
+        <div>child-content</div>
+      </Providers>
+    );
+
+    expect(screen.getByText('child-content')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(setApiClientLocaleMock).toHaveBeenCalledWith('pl');
+      expect(loadAuthTokenFromCookieMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/apiClient.test.ts
+++ b/tests/unit/apiClient.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.cookie = 'authToken=; Path=/; Max-Age=0; SameSite=Lax';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.cookie = 'authToken=; Path=/; Max-Age=0; SameSite=Lax';
+  });
+
+  it('loads the auth token from cookies and applies locale and authorization headers', async () => {
+    const { default: apiClient, loadAuthTokenFromCookie, setApiClientLocale } = await import('@/lib/apiClient');
+
+    document.cookie = 'authToken=cookie-token; Path=/; SameSite=Lax';
+    loadAuthTokenFromCookie();
+    setApiClientLocale('en');
+
+    const requestHandler = (
+      apiClient.interceptors.request as { handlers: Array<{ fulfilled: (config: { headers: Record<string, string> }) => unknown }> }
+    ).handlers[0].fulfilled;
+    const config = requestHandler({ headers: {} }) as { headers: Record<string, string> };
+
+    expect(config.headers.Authorization).toBe('Bearer cookie-token');
+    expect(apiClient.defaults.headers.common['Accept-Language']).toBe('en');
+  });
+
+  it('redirects unauthorized non-login requests to the localized login page', async () => {
+    const { default: apiClient, setAuthToken } = await import('@/lib/apiClient');
+
+    const browserWindow = {
+      location: {
+        pathname: '/en/dashboard',
+        href: '',
+      },
+    };
+
+    vi.stubGlobal('window', browserWindow);
+    setAuthToken('jwt-token');
+
+    const rejectHandler = (apiClient.interceptors.response as { handlers: Array<{ rejected: (error: unknown) => Promise<unknown> }> }).handlers[0]
+      .rejected;
+    const error = {
+      response: { status: 401 },
+      config: { url: '/users/me' },
+    };
+
+    await expect(rejectHandler(error)).rejects.toBe(error);
+    expect(browserWindow.location.href).toBe('/en/auth/login');
+
+    const requestHandler = (
+      apiClient.interceptors.request as { handlers: Array<{ fulfilled: (config: { headers: Record<string, string> }) => unknown }> }
+    ).handlers[0].fulfilled;
+    const config = requestHandler({ headers: {} }) as { headers: Record<string, string> };
+
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('does not redirect when the failed request is the login call itself', async () => {
+    const { default: apiClient } = await import('@/lib/apiClient');
+
+    const browserWindow = {
+      location: {
+        pathname: '/pl/auth/login',
+        href: '',
+      },
+    };
+
+    vi.stubGlobal('window', browserWindow);
+
+    const rejectHandler = (apiClient.interceptors.response as { handlers: Array<{ rejected: (error: unknown) => Promise<unknown> }> }).handlers[0]
+      .rejected;
+    const error = {
+      response: { status: 403 },
+      config: { url: '/auth/login' },
+    };
+
+    await expect(rejectHandler(error)).rejects.toBe(error);
+    expect(browserWindow.location.href).toBe('');
+  });
+});

--- a/tests/unit/layout.test.tsx
+++ b/tests/unit/layout.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('RootLayout', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns the localized document structure for supported locales', async () => {
+    const hasLocaleMock = vi.fn().mockReturnValue(true);
+    const getMessagesMock = vi.fn().mockResolvedValue({ appName: 'FlashCards' });
+
+    vi.doMock('next/font/google', () => ({
+      Roboto: () => ({ variable: '--font-roboto' }),
+    }));
+    vi.doMock('next-intl', () => ({
+      hasLocale: hasLocaleMock,
+    }));
+    vi.doMock('next-intl/server', () => ({
+      getMessages: getMessagesMock,
+    }));
+    vi.doMock('next/navigation', () => ({
+      notFound: vi.fn(),
+    }));
+
+    const { default: RootLayout } = await import('@/app/[locale]/layout');
+    const result = (await RootLayout({
+      children: React.createElement('main', null, 'child-page'),
+      params: Promise.resolve({ locale: 'en' }),
+    })) as React.ReactElement<{ lang: string; children: React.ReactNode }>;
+
+    expect(hasLocaleMock).toHaveBeenCalled();
+    expect(getMessagesMock).toHaveBeenCalled();
+    expect(result.props.lang).toBe('en');
+  });
+
+  it('delegates to notFound for unsupported locales', async () => {
+    const notFoundError = new Error('not-found');
+    const hasLocaleMock = vi.fn().mockReturnValue(false);
+    const notFoundMock = vi.fn(() => {
+      throw notFoundError;
+    });
+
+    vi.doMock('next/font/google', () => ({
+      Roboto: () => ({ variable: '--font-roboto' }),
+    }));
+    vi.doMock('next-intl', () => ({
+      hasLocale: hasLocaleMock,
+    }));
+    vi.doMock('next-intl/server', () => ({
+      getMessages: vi.fn(),
+    }));
+    vi.doMock('next/navigation', () => ({
+      notFound: notFoundMock,
+    }));
+
+    const { default: RootLayout } = await import('@/app/[locale]/layout');
+
+    await expect(
+      RootLayout({
+        children: React.createElement('main', null, 'child-page'),
+        params: Promise.resolve({ locale: 'xx' }),
+      })
+    ).rejects.toThrow('not-found');
+
+    expect(hasLocaleMock).toHaveBeenCalled();
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/logToLoki.test.ts
+++ b/tests/unit/logToLoki.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('logToLoki', () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('window', {
+      location: {
+        pathname: '/pl/profile',
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends a normalized log payload to the API route', async () => {
+    const { logToLoki } = await import('@/helpers/logToLoki');
+
+    await logToLoki({
+      level: 'WARN',
+      msg: 'Something happened',
+      feature: 'profile',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/log-to-loki',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: expect.any(String),
+      })
+    );
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(requestInit.body));
+
+    expect(payload).toMatchObject({
+      level: 'warn',
+      msg: 'Something happened',
+      feature: 'profile',
+      path: '/pl/profile',
+    });
+    expect(payload.timestamp).toEqual(expect.any(String));
+    expect(payload.userAgent).toEqual(expect.any(String));
+  });
+});

--- a/tests/unit/logToLokiRoute.test.ts
+++ b/tests/unit/logToLokiRoute.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const recordRequestMock = vi.fn();
 
@@ -12,6 +12,10 @@ describe('log-to-loki route', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('logs warning payloads and records a successful request', async () => {

--- a/tests/unit/logToLokiRoute.test.ts
+++ b/tests/unit/logToLokiRoute.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const recordRequestMock = vi.fn();
+
+vi.mock('@/lib/observability', () => ({
+  recordRequest: recordRequestMock,
+}));
+
+describe('log-to-loki route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  it('logs warning payloads and records a successful request', async () => {
+    const { POST } = await import('@/app/api/log-to-loki/route');
+
+    const response = await POST(
+      new Request('http://localhost/api/log-to-loki', {
+        method: 'POST',
+        body: JSON.stringify({
+          level: 'WARN',
+          msg: 'hello',
+        }),
+      })
+    );
+
+    expect(await response.text()).toBe('ok');
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('"level":"warn"'));
+    expect(recordRequestMock).toHaveBeenCalledWith('/api/log-to-loki', expect.any(Number), '200', 'POST');
+  });
+
+  it('returns 500 and records a failed request when the payload is invalid', async () => {
+    const { POST } = await import('@/app/api/log-to-loki/route');
+
+    const response = await POST(
+      new Request('http://localhost/api/log-to-loki', {
+        method: 'POST',
+        body: '{invalid-json',
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe('error');
+    expect(console.error).toHaveBeenCalledWith('Error logging to Loki:', expect.anything());
+    expect(recordRequestMock).toHaveBeenCalledWith('/api/log-to-loki', expect.any(Number), '500', 'POST');
+  });
+});

--- a/tests/unit/observability.test.ts
+++ b/tests/unit/observability.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('observability', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    const { register } = await import('prom-client');
+    register.clear();
+
+    delete process.env.APP_NAME;
+    delete process.env.METRICS_BUCKETS;
+    delete process.env.METRICS_PREFIX;
+  });
+
+  it('registers metrics and records requests and errors', async () => {
+    const { activeSessions, cacheSize, errorCounter, recordRequest, register, requestCounter, requestDuration } = await import('@/lib/observability');
+
+    activeSessions.set(3);
+    cacheSize.set(7);
+
+    recordRequest('/api/log-to-loki', 42, '200', 'POST');
+    recordRequest('/api/log-to-loki', 64, '500', 'POST');
+
+    const requests = await requestCounter.get();
+    const errors = await errorCounter.get();
+    const durations = await requestDuration.get();
+
+    expect(register.getSingleMetric('frontend_requests_total')).toBeTruthy();
+    expect(register.getSingleMetric('frontend_errors_total')).toBeTruthy();
+    expect(register.getSingleMetric('frontend_request_duration_ms')).toBeTruthy();
+
+    expect(requests.values).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            method: 'POST',
+            path: '/api/log-to-loki',
+            status: '200',
+          }),
+          value: 1,
+        }),
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            method: 'POST',
+            path: '/api/log-to-loki',
+            status: '500',
+          }),
+          value: 1,
+        }),
+      ])
+    );
+
+    expect(errors.values).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            method: 'POST',
+            path: '/api/log-to-loki',
+            status: '500',
+          }),
+          value: 1,
+        }),
+      ])
+    );
+
+    expect(durations.values.length).toBeGreaterThan(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
-import path from 'path';
+import path from 'node:path';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- clean up SonarCloud code smells in the frontend codebase
- harden Docker build steps to reduce package-install and file-permission hotspots
- simplify observability exports and browser global usage to align with Sonar suggestions

## Verification
- `npm run test`
- `npx eslint src tests eslint.config.mjs vitest.config.ts`
- `npm run build`

Closes Path-Of-Execution-Team/FlashCards#75